### PR TITLE
style: restyled product cards

### DIFF
--- a/src/components/productsCard/ProductCard.tsx
+++ b/src/components/productsCard/ProductCard.tsx
@@ -9,17 +9,17 @@ interface Product {
 }
 
 interface ProductCardProps {
-  product: Product; // Accept product object as a prop
+  product: Product;
 }
 
 const ProductCard = ({ product }: ProductCardProps) => {
   return (
-    <div className="bg-white shadow-md rounded-lg p-4 max-w-xs w-full">
+    <div className="bg-white shadow-md p-4 max-w-80 w-full">
       {product.image_url ? (
         <img
           src={product.image_url}
           alt={`Vinyl cover for ${product.title}`}
-          className="w-full h-48 object-cover rounded-t-lg"
+          className=" object-cover"
         />
       ) : (
         <div className="w-full h-48 bg-gray-200 flex items-center justify-center rounded-t-lg">
@@ -29,9 +29,9 @@ const ProductCard = ({ product }: ProductCardProps) => {
       <div className="p-4">
         <h2 className="text-lg font-bold mb-2">{product.title}</h2>
         <p className="text-gray-600">{product.artist}</p>
-        <p className="text-gray-800 font-semibold">${product.price}</p>
-        <button className="mt-4 bg-blue-500 text-white py-2 px-4 rounded-lg hover:bg-blue-600 transition">
-          View Details
+        <p className="text-gray-800 font-semibold">£{product.price}</p>
+        <button className="mt-4 bg-background-light text-black py-2 px-4 rounded-lg hover:bg-background-footer transition">
+          Add To Basket
         </button>
       </div>
     </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -44,14 +44,14 @@ const Home = () => {
         Discover and collect your favorite vinyl records
       </p>
 
-      <section className="mb-12 w-full" aria-labelledby="new-on-store">
+      <section className="mb-12 max-w-90" aria-labelledby="new-on-store">
         <h3
           id="new-on-store"
           className="text-2xl font-semibold mb-4 text-text-primary"
         >
           New on Store
         </h3>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-10">
           {productData.map((product) => (
             <ProductCard key={product.id} product={product} />
           ))}


### PR DESCRIPTION
## Update Product Image and Card Layout

### Summary
This pull request makes improvements to the product image layout and card display on the product listing page to enhance user experience and improve usability.

### Changes:
   - Changed the product images to be square, giving them an album-cover look.
   - Ensured that images are no longer cropped, maintaining consistent dimensions across the page.
   - Adjusted card dimensions to fit more products on the screen at once.
   - Centered the cards for a cleaner, more organised display.
   - Replaced the "More Info" button with an "Add to Basket" button for a more direct call to action.
   - in the future we can make both the product name and product image clickable links that take the user to a dedicated product page with more detailed information.



### Screenshots:

![PRoductCards Design](https://github.com/user-attachments/assets/3a4e6d39-9292-4ec2-8f84-3908f3340352)
