### PR TITLE
feat(CartSummary): fetch shipping option from backend

### DIFF
--- a/src/utils/fetch-data.ts
+++ b/src/utils/fetch-data.ts
@@ -1,10 +1,13 @@
+type FetchDataResponse = { [key: string]: any };
+
 const fetchData = async (
   table: string,
   method: string,
-  body?: any,
-): Promise<any> => {
+  body?: string,
+): Promise<FetchDataResponse> => {
   try {
-    const response = await fetch(`http://18.175.143.146:3000/${table}`, {
+    const response = await fetch(`http://localhost:3000/${table}`, {
+      // const response = await fetch(`http://18.175.143.146:3000/${table}`, {
       method: method,
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
This pull request updates the CartSummary component to include dynamic shipping options fetched from the database.

Key Changes:

- Retrieves shipping options from /shipping-options API, including id, shipping_option name, price, lead_time_days, and locations.
- Added a dropdown allowing users to select their shipping method. Each option shows the name, cost, and delivery time.
- Calculates delivery charge based on the selected shipping option. If the cart total is below the free shipping threshold, the charge is applied; otherwise, it’s set to £0.
- Used useState to store selected shipping. Defaults to the first option if none is selected.